### PR TITLE
Require passing stored record Type information

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.transferwise.idempotence4j
-version=1.0.5
+version=1.1.0

--- a/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/IdempotenceService.java
+++ b/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/IdempotenceService.java
@@ -1,12 +1,23 @@
 package com.transferwise.idempotence4j.core;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.lang.reflect.Type;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public interface IdempotenceService {
-    <S, R> R execute(ActionId actionId, Function<S, R> onRetry, Supplier<R> procedure, Function<R, S> toRecord);
+    <S, R> R execute(ActionId actionId, Function<S, R> onRetry, Supplier<R> procedure, Function<R, S> toRecord, Type recordType);
 
-    default <R> R execute(ActionId actionId, Supplier<R> action) {
-        return execute(actionId, Function.identity(), action, Function.identity());
+    default <S, R> R execute(ActionId actionId, Function<S, R> onRetry, Supplier<R> procedure, Function<R, S> toRecord, TypeReference<S> recordTypeRef) {
+        return execute(actionId, onRetry, procedure, toRecord, recordTypeRef.getType());
+    }
+
+    default <R> R execute(ActionId actionId, Supplier<R> action, Type recordType) {
+        return execute(actionId, Function.identity(), action, Function.identity(), recordType);
+    }
+
+    default <R> R execute(ActionId actionId, Supplier<R> action, TypeReference<R> recordTypeRef) {
+        return execute(actionId, Function.identity(), action, Function.identity(), recordTypeRef);
     }
 }

--- a/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/ResultSerializer.java
+++ b/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/ResultSerializer.java
@@ -1,6 +1,7 @@
 package com.transferwise.idempotence4j.core;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * An action result serializer/de-serializer.
@@ -13,7 +14,7 @@ import java.io.IOException;
 public interface ResultSerializer {
     <T> byte[] serialize(T result) throws IOException;
 
-    <T> T deserialize(byte[] payload) throws IOException;
+    <T> T deserialize(byte[] payload, Type type) throws IOException;
 
     String getType();
 }

--- a/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/serializers/json/JsonResultSerializer.java
+++ b/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/serializers/json/JsonResultSerializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.idempotence4j.core.ResultSerializer;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 public class JsonResultSerializer implements ResultSerializer {
     private final ObjectMapper objectMapper;
@@ -19,8 +20,8 @@ public class JsonResultSerializer implements ResultSerializer {
     }
 
     @Override
-    public <T> T deserialize(byte[] payload) throws IOException {
-        return objectMapper.readValue(payload, new TypeReference<T>() {});
+    public <T> T deserialize(byte[] payload, Type type) throws IOException {
+        return objectMapper.readValue(payload, objectMapper.constructType(type));
     }
 
     @Override

--- a/idempotence4j-test/src/main/groovy/com/transferwise/idempotence4j/core/EphemeralIdempotenceService.groovy
+++ b/idempotence4j-test/src/main/groovy/com/transferwise/idempotence4j/core/EphemeralIdempotenceService.groovy
@@ -2,6 +2,7 @@ package com.transferwise.idempotence4j.core
 
 import groovy.transform.Synchronized
 
+import java.lang.reflect.Type
 import java.util.function.Function
 import java.util.function.Supplier
 
@@ -10,7 +11,7 @@ class EphemeralIdempotenceService implements IdempotenceService {
 
     @Override
     @Synchronized
-    def <S, R> R execute(ActionId actionId, Function<S, R> onRetry, Supplier<R> procedure, Function<R, S> toRecord) {
+    def <S, R> R execute(ActionId actionId, Function<S, R> onRetry, Supplier<R> procedure, Function<R, S> toRecord, Type recordType) {
         if(storage.containsKey(actionId)) {
             return onRetry(storage.get(actionId))
         }

--- a/idempotence4j-test/src/main/groovy/com/transferwise/idempotence4j/factory/ActionTestFactory.groovy
+++ b/idempotence4j-test/src/main/groovy/com/transferwise/idempotence4j/factory/ActionTestFactory.groovy
@@ -4,6 +4,7 @@ import com.transferwise.idempotence4j.core.Action
 import com.transferwise.idempotence4j.core.ActionId
 import com.transferwise.idempotence4j.core.Result
 import groovy.json.JsonOutput
+import groovy.transform.EqualsAndHashCode
 import groovy.transform.TupleConstructor
 
 import java.nio.charset.StandardCharsets
@@ -55,6 +56,7 @@ class ActionTestFactory {
     }
 
     @TupleConstructor()
+    @EqualsAndHashCode
     static class TestResult {
         String name
         Integer age


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context <!-- why this change is made -->
Since we do not store persisted record type information we need to ask clients to explicitly pass it to the IdempotenceService

## 🚀 Changes <!-- what this PR does -->


## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
