### PR TITLE
Add flyway usage warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ and autowires service `Beans`. Otherwise, you can add a dependency on each modul
 
 ```gradle
 dependencies {
-  implementation "com.transferwise.idempotence4j:idempotence4j-core:${project['idempotence4j.version']}"  
+  implementation "com.transferwise.idempotence4j:idempotence4j-core:${project['idempotence4j.version']}"
 }
 ```
 
@@ -84,11 +84,18 @@ To add PostgresSQL module to your build using Gradle, use the following:
 
 ```gradle
 dependencies {
-  implementation "com.transferwise.idempotence4j:idempotence4j-postgres:${project['idempotence4j.version']}"  
+  implementation "com.transferwise.idempotence4j:idempotence4j-postgres:${project['idempotence4j.version']}"
 }
 ```
 
 ### Flyway
+
+> :exclamation: **_Important:_**  Flyway by default doesn't allow to apply "out of order" migrations, that means
+> if you have already applied a migration with version `3`, adding migration version `1` will cause an error.
+>
+> Since `idempotence4j` is using a timestamp versions it can cause a number of issues, i.e. if in your project you use incremented numeric versions.
+
+Please **only use the following configuration approach** if your flyway configuration has `flyway.outOfOrder` flag enabled, otherwise please create an exact copy of these migrations in your project flyway module.
 
 `Postgres` module contains Flyway migration definitions to keep required tables schemas up-to-date. Both `yaml` and `java` configuration examples provided below:
 

--- a/doc/architecture/decisions/0001-idempotence-service.md
+++ b/doc/architecture/decisions/0001-idempotence-service.md
@@ -36,16 +36,6 @@ We require request execution logic and idempotence status update to happen in a 
 That requirement comes at a cost of the client flexibility. Allowing clients to control transactional context
 introduces edge-cases such as a failure to persist idempotency status whereas action has been completed and side effect taken place.
 
-In future though
-
-
-As much as we want to optimize for the flexibility on the client side
-we try to avoid clients to perform validation checks if action has
-
-As much as we want to optimize for the flexibity provided to clients of this library,
-
-We aim to provide as much flexibility to the clients as possible
-
 ## Decision
 
 Provide code idempotence service based on a database approach, specific database integration is pluggable.


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context <!-- why this change is made -->
Flyway applied migration versions ordering validation on all discovered migrations under defined modules, that can cause issues if the project defines migrations using numeric id or in the future if a newly added idempotence4j migration would be dated before the latest project migration.

## 🚀 Changes <!-- what this PR does -->
- README

## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
- File a ticket on the flyway project to consider applying version ordering by modules, rather than collecting all discovered migration scripts into one set.