### PR TITLE
Hold action instance in acquired lock

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.transferwise.idempotence4j
-version=1.1.1
+version=1.2.0

--- a/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/DefaultIdempotenceService.java
+++ b/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/DefaultIdempotenceService.java
@@ -76,7 +76,7 @@ public class DefaultIdempotenceService implements IdempotenceService {
             Lock lock = lockProvider.lock(actionId).orElseThrow(() -> new ConflictingActionException("Request already in progress"));
 
             try (lock) {
-                Action pendingAction = actionRepository.find(actionId).get();
+                Action pendingAction = lock.getLockedAction();
                 if (pendingAction.hasCompleted()) {
                     return processRetry(pendingAction, onRetry, recordType, metrics);
                 }

--- a/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/Lock.java
+++ b/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/Lock.java
@@ -1,12 +1,26 @@
 package com.transferwise.idempotence4j.core;
 
+import lombok.Getter;
+import lombok.NonNull;
+
 import java.io.Closeable;
 
-public interface Lock extends Closeable {
-    void release();
+/**
+ * Lock object holds an action under lock retrieved after lock was acquired.
+ * That comes handy for database backed lock provider implementation as we can then avoid an extra database round trip.
+ */
+public abstract class Lock implements Closeable {
+    @Getter
+    private final Action lockedAction;
+
+    public Lock(@NonNull Action lockedAction) {
+        this.lockedAction = lockedAction;
+    }
+
+    abstract public void release();
 
     @Override
-    default void close() {
+    public void close() {
         this.release();
     }
 }

--- a/idempotence4j-postgres/src/main/java/com/transferwise/idempotence4j/postgres/JdbcPostgresLockProvider.java
+++ b/idempotence4j-postgres/src/main/java/com/transferwise/idempotence4j/postgres/JdbcPostgresLockProvider.java
@@ -3,6 +3,7 @@ package com.transferwise.idempotence4j.postgres;
 import com.transferwise.idempotence4j.core.ActionId;
 import com.transferwise.idempotence4j.core.Lock;
 import com.transferwise.idempotence4j.core.LockProvider;
+import com.transferwise.idempotence4j.jdbc.mapper.ActionSqlMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -11,6 +12,7 @@ import java.util.Optional;
 
 public class JdbcPostgresLockProvider implements LockProvider {
 	private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final ActionSqlMapper sqlMapper = new ActionSqlMapper();
 
 	public JdbcPostgresLockProvider(JdbcTemplate jdbcTemplate) {
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
@@ -23,12 +25,15 @@ public class JdbcPostgresLockProvider implements LockProvider {
             .addValue("type", actionId.getType())
             .addValue("client", actionId.getClient());
 
-		return namedParameterJdbcTemplate.query(LOCK_SQL, parameters, (rs, rowNum) -> new PostgresRowLock()).stream().findFirst();
+		return namedParameterJdbcTemplate.query(LOCK_SQL, parameters, (rs, rowNum) -> new PostgresRowLock(sqlMapper.toEntity(rs)))
+            .stream()
+            .findFirst();
 	}
 
 	//@formatter:off
 	private final static String LOCK_SQL =
-			"SELECT 1 " +
+            "SELECT " +
+                "key, type, client, created_at, last_run_at, completed_at, result, result_type " +
 			"FROM idempotent_action " +
 			"WHERE " +
 				"key = :key " +

--- a/idempotence4j-postgres/src/main/java/com/transferwise/idempotence4j/postgres/PostgresRowLock.java
+++ b/idempotence4j-postgres/src/main/java/com/transferwise/idempotence4j/postgres/PostgresRowLock.java
@@ -1,8 +1,14 @@
 package com.transferwise.idempotence4j.postgres;
 
+import com.transferwise.idempotence4j.core.Action;
 import com.transferwise.idempotence4j.core.Lock;
+import lombok.NonNull;
 
-public class PostgresRowLock implements Lock {
+public class PostgresRowLock extends Lock {
+
+    public PostgresRowLock(@NonNull Action action) {
+        super(action);
+    }
 
     @Override
     public void release() {

--- a/idempotence4j-postgres/src/test-integration/groovy/com/transferwise/idempotence4j/postgres/JdbcPostgresLockProviderIntegrationTest.groovy
+++ b/idempotence4j-postgres/src/test-integration/groovy/com/transferwise/idempotence4j/postgres/JdbcPostgresLockProviderIntegrationTest.groovy
@@ -1,0 +1,29 @@
+package com.transferwise.idempotence4j.postgres
+
+import com.transferwise.idempotence4j.core.Action
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import spock.lang.Subject
+
+import static com.transferwise.idempotence4j.factory.ActionTestFactory.anActionId
+
+class JdbcPostgresLockProviderIntegrationTest extends IntegrationTest {
+    def jdbcTemplate = new JdbcTemplate(dataSource)
+    def transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(dataSource))
+    def repository = new JdbcPostgresActionRepository(jdbcTemplate)
+    @Subject
+    def lockProvider = new JdbcPostgresLockProvider(jdbcTemplate)
+
+    def "should successfully acquire lock and retrieve locked action"() {
+        given:
+            def actionId = anActionId()
+        and:
+            repository.insertOrGet(new Action(actionId))
+        when:
+            def lock = transactionTemplate.execute({ lockProvider.lock(actionId) } )
+        then:
+            lock.isPresent()
+            lock.get().getLockedAction().actionId == actionId
+    }
+}

--- a/idempotence4j-test/src/main/groovy/com/transferwise/idempotence4j/core/NoOpLock.java
+++ b/idempotence4j-test/src/main/groovy/com/transferwise/idempotence4j/core/NoOpLock.java
@@ -1,0 +1,15 @@
+package com.transferwise.idempotence4j.core;
+
+import lombok.NonNull;
+
+public class NoOpLock extends Lock {
+
+    public NoOpLock(@NonNull Action lockedAction) {
+        super(lockedAction);
+    }
+
+    @Override
+    public void release() {
+        //no op
+    }
+}


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context <!-- why this change is made -->
To avoid an unnecessary database round trip in case of database-backed lock providers, we can retrieve action payload at the same time as we put a row-level lock on it.

## 🚀 Changes <!-- what this PR does -->
- Lock (interface -> abstract class)
- JdbcPostgresLockProvider

## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
