### PR TITLE
Deleting gradle release plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<a href="https://img.shields.io/badge/release-1.4.5-orange">
-        <img src="https://img.shields.io/badge/release-1.4.5-orange"
+<a href="https://img.shields.io/badge/release-1.4.7-orange">
+        <img src="https://img.shields.io/badge/release-1.4.7-orange"
             alt="Release version"/></a>
 
 # idempotence4j

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 		mavenLocal()
 	}
 	dependencies {
-		classpath 'net.researchgate:gradle-release:2.8.1'
 		classpath 'org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:2.1.1'
 		classpath "com.avast.gradle:gradle-docker-compose-plugin:0.12.1"
         classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
@@ -25,7 +24,6 @@ allprojects {
 	apply plugin: 'java-library'
 	apply plugin: 'groovy'
 	apply plugin: 'maven-publish'
-	apply plugin: 'net.researchgate.release'
 	apply plugin: 'org.unbroken-dome.test-sets'
 	apply from: "${rootDir}/libraries.gradle"
 	apply from: "${rootDir}/publish.gradle"
@@ -85,7 +83,6 @@ allprojects {
 		}
 	}
 	check.dependsOn integrationTest
-	afterReleaseBuild.dependsOn publish
 
 	ext.isRunningOnCI = {
 		System.getenv("CI") == "true"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.transferwise.idempotence4j
-version=1.4.6
+version=1.4.7


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context <!-- why this change is made -->
Deleting `gradle-release` plugin, as we don't use it.

## 🚀 Changes <!-- what this PR does -->


## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
- Considering using `axion-release-plugin` for automatic handling of semantic versioning based on `git` release tag