### PR TITLE
v1.7.0 - Enable action deletion by type and client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.7.0 - 2022-04-19
+- `deleteOlderThan` method on `ActionRepository` now forces use of a primitive for batch size.
+- Begin returning the number of rows deleted from deletion methods in `ActionRepository`
+- Exposed a `deleteByTypeAndClient` method on `ActionRepository`
+- Deletion of old action IDs is now more performant on MariaDB
+
 ## 1.6.0 - 2022-04-08
 
 expose ActionRepository deleteByIds method

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.transferwise.idempotence4j
-version=1.6.1
+version=1.7.0

--- a/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/ActionRepository.java
+++ b/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/ActionRepository.java
@@ -8,6 +8,16 @@ public interface ActionRepository {
     Optional<Action> find(ActionId actionId);
     Action insertOrGet(Action action);
     Action update(Action action);
-    void deleteOlderThan(Instant timestamp, int batchSize);
-    void deleteByIds(List<ActionId> actionIds);
+
+    /**
+     * Deletes actions from the repository that were first executed before the provided timestamp, and limited by the batch size.
+     * @return the number of actions deleted
+     */
+    int deleteOlderThan(Instant timestamp, int batchSize);
+
+    /**
+     * Batch deletes actions from the repository by their IDs.
+     * @return An array containing the number of actions deleted, per action ID passed in as an argument.
+     */
+    int[] deleteByIds(List<ActionId> actionIds);
 }

--- a/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/ActionRepository.java
+++ b/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/ActionRepository.java
@@ -16,6 +16,12 @@ public interface ActionRepository {
     int deleteOlderThan(Instant timestamp, int batchSize);
 
     /**
+     * Batch deletes actions from the repository by type and client, limited by the batch size.
+     * @return the number of actions deleted
+     */
+    int deleteByTypeAndClient(String type, String client, int batchSize);
+
+    /**
      * Batch deletes actions from the repository by their IDs.
      * @return An array containing the number of actions deleted, per action ID passed in as an argument.
      */

--- a/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/ActionRepository.java
+++ b/idempotence4j-core/src/main/java/com/transferwise/idempotence4j/core/ActionRepository.java
@@ -8,6 +8,6 @@ public interface ActionRepository {
     Optional<Action> find(ActionId actionId);
     Action insertOrGet(Action action);
     Action update(Action action);
-    void deleteOlderThan(Instant timestamp, Integer batchSize);
+    void deleteOlderThan(Instant timestamp, int batchSize);
     void deleteByIds(List<ActionId> actionIds);
 }

--- a/idempotence4j-mariadb/src/main/java/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepository.java
+++ b/idempotence4j-mariadb/src/main/java/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepository.java
@@ -68,7 +68,7 @@ public class JdbcMariaDbActionRepository implements ActionRepository {
             .addValue("client", actionId.getClient()))
             .toArray(size -> new MapSqlParameterSource[size]);
 
-        return namedParameterJdbcTemplate.batchUpdate(DELETE_SQL, deleteBatchParameters);
+        return namedParameterJdbcTemplate.batchUpdate(DELETE_BY_ACTION_ID_SQL, deleteBatchParameters);
     }
 
     //@formatter:off
@@ -129,7 +129,7 @@ public class JdbcMariaDbActionRepository implements ActionRepository {
             "created_at < :createdAt " +
             "LIMIT :limit";
 
-    private final static String DELETE_SQL =
+    private final static String DELETE_BY_ACTION_ID_SQL =
         "DELETE " +
             "FROM idempotent_action " +
             "WHERE " +

--- a/idempotence4j-mariadb/src/main/java/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepository.java
+++ b/idempotence4j-mariadb/src/main/java/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepository.java
@@ -48,7 +48,7 @@ public class JdbcMariaDbActionRepository implements ActionRepository {
 	}
 
     @Override
-    public void deleteOlderThan(Instant timestamp, Integer batchSize) {
+    public void deleteOlderThan(Instant timestamp, int batchSize) {
         MapSqlParameterSource queryParameters = new MapSqlParameterSource()
             .addValue("createdAt", Timestamp.from(timestamp))
             .addValue("limit", batchSize);

--- a/idempotence4j-mariadb/src/main/java/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepository.java
+++ b/idempotence4j-mariadb/src/main/java/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepository.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,25 +49,26 @@ public class JdbcMariaDbActionRepository implements ActionRepository {
 	}
 
     @Override
-    public void deleteOlderThan(Instant timestamp, int batchSize) {
+    public int deleteOlderThan(Instant timestamp, int batchSize) {
         MapSqlParameterSource queryParameters = new MapSqlParameterSource()
             .addValue("createdAt", Timestamp.from(timestamp))
             .addValue("limit", batchSize);
 
         List<ActionId> actionIdList = namedParameterJdbcTemplate.query(FIND_OLDER_THAN_SQL, queryParameters, (rs, rowNum) -> sqlMapper.toId(rs));
 
-        deleteByIds(actionIdList);
+        int[] rowsDeleted = deleteByIds(actionIdList);
+        return Arrays.stream(rowsDeleted).sum();
     }
 
     @Override
-    public void deleteByIds(List<ActionId> actionIdList) {
+    public int[] deleteByIds(List<ActionId> actionIdList) {
         MapSqlParameterSource[] deleteBatchParameters = actionIdList.stream().map(actionId -> new MapSqlParameterSource()
             .addValue("key", actionId.getKey())
             .addValue("type", actionId.getType())
             .addValue("client", actionId.getClient()))
             .toArray(size -> new MapSqlParameterSource[size]);
 
-        namedParameterJdbcTemplate.batchUpdate(DELETE_SQL, deleteBatchParameters);
+        return namedParameterJdbcTemplate.batchUpdate(DELETE_SQL, deleteBatchParameters);
     }
 
     //@formatter:off

--- a/idempotence4j-mariadb/src/main/java/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepository.java
+++ b/idempotence4j-mariadb/src/main/java/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepository.java
@@ -57,6 +57,16 @@ public class JdbcMariaDbActionRepository implements ActionRepository {
     }
 
     @Override
+    public int deleteByTypeAndClient(String type, String client, int batchSize) {
+        MapSqlParameterSource deleteParameters = new MapSqlParameterSource()
+            .addValue("type", type)
+            .addValue("client", client)
+            .addValue("limit", batchSize);
+
+        return namedParameterJdbcTemplate.update(DELETE_BY_TYPE_AND_CLIENT_SQL, deleteParameters);
+    }
+
+    @Override
     public int[] deleteByIds(List<ActionId> actionIdList) {
         MapSqlParameterSource[] deleteBatchParameters = actionIdList.stream().map(actionId -> new MapSqlParameterSource()
             .addValue("key", actionId.getKey())
@@ -121,6 +131,13 @@ public class JdbcMariaDbActionRepository implements ActionRepository {
         "DELETE FROM idempotent_action " +
             "WHERE " +
             "created_at < :createdAt " +
+            "LIMIT :limit";
+
+    private final static String DELETE_BY_TYPE_AND_CLIENT_SQL =
+        "DELETE FROM idempotent_action " +
+            "WHERE type = :type " +
+            "  AND client = :client " +
+            "ORDER BY created_at ASC " +
             "LIMIT :limit";
 
     private final static String DELETE_BY_ACTION_ID_SQL =

--- a/idempotence4j-mariadb/src/test-integration/groovy/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepositoryIntegrationTest.groovy
+++ b/idempotence4j-mariadb/src/test-integration/groovy/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepositoryIntegrationTest.groovy
@@ -79,12 +79,14 @@ class JdbcMariaDbActionRepositoryIntegrationTest extends IntegrationTest {
         and:
             actions.each { it -> repository.insertOrGet(it) }
         when:
-            repository.deleteOlderThan(Instant.parse("2019-12-11T00:00:00Z"), 5)
+            int firstDeletionCount = repository.deleteOlderThan(Instant.parse("2019-12-11T00:00:00Z"), 5)
         then:
+            firstDeletionCount == 5
             countActions() == 15
         when:
-            repository.deleteOlderThan(Instant.parse("2019-12-11T00:00:00Z"), 5)
+            int secondDeletionCount = repository.deleteOlderThan(Instant.parse("2019-12-11T00:00:00Z"), 5)
         then:
+            secondDeletionCount == 5
             countActions() == 10
         and:
             purged.each { Action it ->
@@ -103,12 +105,14 @@ class JdbcMariaDbActionRepositoryIntegrationTest extends IntegrationTest {
             def firstHalfActionIds = actionIds.dropRight(actions.size() / 2 as int)
             def lastHalfActionIds = actionIds.drop(actions.size() / 2 as int)
         when:
-            repository.deleteByIds(firstHalfActionIds)
+            int[] firstRowsDeleted = repository.deleteByIds(firstHalfActionIds)
+            firstRowsDeleted == [1, 1, 1, 1, 1] as int[]
         then:
             firstHalfActionIds.each { ActionId it -> assert repository.find(it).isEmpty() }
             lastHalfActionIds.each { ActionId it -> assert !repository.find(it).isEmpty() }
         when:
-            repository.deleteByIds(lastHalfActionIds)
+            int[] secondRowsDeleted = repository.deleteByIds(lastHalfActionIds)
+            secondRowsDeleted == [1, 1, 1, 1, 1] as int[]
         then:
             actionIds.each { ActionId it ->
                 assert repository.find(it).isEmpty()

--- a/idempotence4j-mariadb/src/test-integration/groovy/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepositoryIntegrationTest.groovy
+++ b/idempotence4j-mariadb/src/test-integration/groovy/com/transferwise/idempotence4j/mariadb/JdbcMariaDbActionRepositoryIntegrationTest.groovy
@@ -9,6 +9,8 @@ import spock.lang.Subject
 import java.time.Clock
 import java.time.Instant
 
+import static com.transferwise.idempotence4j.factory.ActionTestFactory.CLIENT
+import static com.transferwise.idempotence4j.factory.ActionTestFactory.TYPE
 import static com.transferwise.idempotence4j.factory.ActionTestFactory.anAction
 import static com.transferwise.idempotence4j.factory.ActionTestFactory.anActionId
 import static com.transferwise.idempotence4j.factory.ActionTestFactory.anActionResult
@@ -91,6 +93,31 @@ class JdbcMariaDbActionRepositoryIntegrationTest extends IntegrationTest {
         and:
             purged.each { Action it ->
                 assert repository.find(it.actionId).isEmpty()
+            }
+    }
+
+    def "should remove actions by type and client"() {
+        given:
+            def actions = []
+            10.times {
+                actions << anAction()
+            }
+        and:
+            List<ActionId> actionIds = actions.each { it -> repository.insertOrGet(it) } .collect({ it.actionId })
+            def firstHalfActionIds = actionIds.dropRight(actions.size() / 2 as int)
+            def lastHalfActionIds = actionIds.drop(actions.size() / 2 as int)
+        when:
+            int firstDeletionCount = repository.deleteByTypeAndClient(TYPE, CLIENT, 5)
+        then:
+            firstDeletionCount == 5
+            firstHalfActionIds.each { ActionId it -> assert repository.find(it).isEmpty() }
+            lastHalfActionIds.each { ActionId it -> assert !repository.find(it).isEmpty() }
+        when:
+            int secondDeletionCount = repository.deleteByTypeAndClient(TYPE, CLIENT, 5)
+        then:
+            secondDeletionCount == 5
+            actionIds.each { ActionId it ->
+                assert repository.find(it).isEmpty()
             }
     }
 

--- a/idempotence4j-postgres/src/main/java/com/transferwise/idempotence4j/postgres/JdbcPostgresActionRepository.java
+++ b/idempotence4j-postgres/src/main/java/com/transferwise/idempotence4j/postgres/JdbcPostgresActionRepository.java
@@ -50,7 +50,7 @@ public class JdbcPostgresActionRepository implements ActionRepository {
 	}
 
     @Override
-    public void deleteOlderThan(Instant timestamp, Integer batchSize) {
+    public void deleteOlderThan(Instant timestamp, int batchSize) {
         MapSqlParameterSource queryParameters = new MapSqlParameterSource()
             .addValue("createdAt", Timestamp.from(timestamp))
             .addValue("limit", batchSize);

--- a/idempotence4j-postgres/src/main/java/com/transferwise/idempotence4j/postgres/JdbcPostgresActionRepository.java
+++ b/idempotence4j-postgres/src/main/java/com/transferwise/idempotence4j/postgres/JdbcPostgresActionRepository.java
@@ -70,7 +70,7 @@ public class JdbcPostgresActionRepository implements ActionRepository {
             .addValue("client", actionId.getClient()))
             .toArray(size -> new MapSqlParameterSource[size]);
 
-        return namedParameterJdbcTemplate.batchUpdate(DELETE_SQL, deleteBatchParameters);
+        return namedParameterJdbcTemplate.batchUpdate(DELETE_BY_ACTION_ID_SQL, deleteBatchParameters);
     }
 
     //@formatter:off
@@ -128,7 +128,7 @@ public class JdbcPostgresActionRepository implements ActionRepository {
             "created_at < :createdAt " +
             "LIMIT :limit";
 
-    private final static String DELETE_SQL =
+    private final static String DELETE_BY_ACTION_ID_SQL =
         "DELETE " +
             "FROM idempotent_action " +
             "WHERE " +

--- a/idempotence4j-postgres/src/test-integration/groovy/com/transferwise/idempotence4j/postgres/JdbcPostgresActionRepositoryIntegrationTest.groovy
+++ b/idempotence4j-postgres/src/test-integration/groovy/com/transferwise/idempotence4j/postgres/JdbcPostgresActionRepositoryIntegrationTest.groovy
@@ -79,12 +79,14 @@ class JdbcPostgresActionRepositoryIntegrationTest extends IntegrationTest {
         and:
             actions.each { it -> repository.insertOrGet(it) }
         when:
-            repository.deleteOlderThan(Instant.parse("2019-12-11T00:00:00Z"), 5)
+            int firstDeletionCount = repository.deleteOlderThan(Instant.parse("2019-12-11T00:00:00Z"), 5)
         then:
+            firstDeletionCount == 5
             countActions() == 15
         when:
-            repository.deleteOlderThan(Instant.parse("2019-12-11T00:00:00Z"), 5)
+            int secondDeletionCount = repository.deleteOlderThan(Instant.parse("2019-12-11T00:00:00Z"), 5)
         then:
+            secondDeletionCount == 5
             countActions() == 10
         and:
             purged.each { Action it ->
@@ -103,13 +105,15 @@ class JdbcPostgresActionRepositoryIntegrationTest extends IntegrationTest {
             def firstHalfActionIds = actionIds.dropRight(actions.size() / 2 as int)
             def lastHalfActionIds = actionIds.drop(actions.size() / 2 as int)
         when:
-            repository.deleteByIds(firstHalfActionIds)
+            int[] firstRowsDeleted = repository.deleteByIds(firstHalfActionIds)
         then:
+            firstRowsDeleted == [1, 1, 1, 1, 1] as int[]
             firstHalfActionIds.each { ActionId it -> assert repository.find(it).isEmpty() }
             lastHalfActionIds.each { ActionId it -> assert !repository.find(it).isEmpty() }
         when:
-            repository.deleteByIds(lastHalfActionIds)
+            int[] secondRowsDeleted = repository.deleteByIds(lastHalfActionIds)
         then:
+            secondRowsDeleted == [1, 1, 1, 1, 1] as int[]
             actionIds.each { ActionId it ->
                 assert repository.find(it).isEmpty()
             }

--- a/idempotence4j-test/src/main/groovy/com/transferwise/idempotence4j/factory/ActionTestFactory.groovy
+++ b/idempotence4j-test/src/main/groovy/com/transferwise/idempotence4j/factory/ActionTestFactory.groovy
@@ -12,11 +12,15 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 
 class ActionTestFactory {
+
+    static final String TYPE = "ADD"
+    static final String CLIENT = "aService"
+
     static anActionId(
         Map args = [:],
         String key = UUID.randomUUID().toString(),
-        String type = "ADD",
-        String client = "aService"
+        String type = TYPE,
+        String client = CLIENT
     ) {
         new ActionId(
             args.key as String ?: key,


### PR DESCRIPTION
- `deleteOlderThan` method on `ActionRepository` now forces use of a primitive for batch size.
The existing code previously allowed a batchSize of 'null' to be passed in, leading to inconsistent behaviour across implementations:
MariaDB throws an exception:
> You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'NULL' at line 1

Postgres treats 'null' as a zero, i.e. delete nothing.

To remedy this, changing the boxed type to a primitive, forcing developers to provide a valid value. Not marking as breaking as passing a null would not have worked any way.

- Begin returning the number of rows deleted from deletion methods in `ActionRepository`
To support the above, return results of deletion methods that engineers understand whether the deletion limit was reached or not - i.e. whether they should continue to paginate.

- Exposed a `deleteByTypeAndClient` method on `ActionRepository`

- Deletion of old action IDs is now more performant on MariaDB
Uses `DELETE FROM ... LIMIT` construct that is available on MariaDB. This removes the need to read action IDs in to memory, and then delete them in a separate query.