### PR TITLE
bump cron-utils to fix vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.7.1 - 2022-05-03
+bump cron-utils to fix avd.aquasec.com/nvd/cve-2021-41269
+
 ## 1.7.0 - 2022-04-19
 - `deleteOlderThan` method on `ActionRepository` now forces use of a primitive for batch size.
 - Begin returning the number of rows deleted from deletion methods in `ActionRepository`

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -14,7 +14,7 @@ ext {
     postgresqlVersion = '42.2.16'
     mariaDbVersion = '2.5.2'
     dbSchedulerVersion = '7.2'
-    cronUtilsVersion = '8.0.0'
+    cronUtilsVersion = '9.1.6'
     uuidCreatorVersion = '2.7.10'
 
     jmhVersion = '1.25.2'


### PR DESCRIPTION
## ❓ Context 
bump cron-utils to fix vulnerability https://avd.aquasec.com/nvd/2021/cve-2021-41269/

## 🚀 Changes
bump cron-utils

## 💬 Considerations 
