### PR TITLE
Bump jackson-datatype version to close vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ## 1.7.1 - 2022-05-03
 bump cron-utils to fix avd.aquasec.com/nvd/cve-2021-41269
+bump jackson-datatype to fix https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2018-1000873
 
 ## 1.7.0 - 2022-04-19
 - `deleteOlderThan` method on `ActionRepository` now forces use of a primitive for batch size.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<a href="https://img.shields.io/badge/release-1.6.1-orange">
-        <img src="https://img.shields.io/badge/release-1.6.1-orange"
+<a href="https://img.shields.io/badge/release-1.7.1-orange">
+        <img src="https://img.shields.io/badge/release-1.7.1-orange"
             alt="Release version"/></a>
 
 # idempotence4j

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.transferwise.idempotence4j
-version=1.7.0
+version=1.7.1

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -1,7 +1,7 @@
 ext {
     lombokVersion = '1.18.10'
     slf4jVersion = '1.7.26'
-    jacksonVersion = '2.9.7'
+    jacksonVersion = '2.13.2'
     micrometerVersion = '1.3.5'
 
     springVersion = '2.2.4.RELEASE'


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context <!-- why this change is made -->
Bump jackson-datatype version to close vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000873

## 🚀 Changes <!-- what this PR does -->
- libraries version

## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
