### PR TITLE
feat: bump db-scheduler to 11.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.transferwise.idempotence4j
-version=1.7.1
+version=1.8.0

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -13,7 +13,7 @@ ext {
     flywayVersion = '6.1.4'
     postgresqlVersion = '42.2.16'
     mariaDbVersion = '2.5.2'
-    dbSchedulerVersion = '7.2'
+    dbSchedulerVersion = '11.2'
     cronUtilsVersion = '9.1.6'
     uuidCreatorVersion = '2.7.10'
 


### PR DESCRIPTION
## ❓ Context <!-- why this change is made -->

Bump db-scheduler dependency version to fix CRITICAL [CVE-2021-41269](https://nvd.nist.gov/vuln/detail/CVE-2021-41269). (db-scheduler includes cron-utils with shadowing.)

Luckily, [db ddl](https://github.com/kagkarlsson/db-scheduler/blob/master/db-scheduler/src/test/resources/mysql_tables.sql) has not changed.

## 🚀 Changes <!-- what this PR does -->

- bump dependency version to 11.2
- bump library version to 1.8.0

## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
