### PR TITLE
Bump db-scheduler version to 11.0

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -13,7 +13,7 @@ ext {
     flywayVersion = '6.1.4'
     postgresqlVersion = '42.2.16'
     mariaDbVersion = '2.5.2'
-    dbSchedulerVersion = '7.2'
+    dbSchedulerVersion = '11.0'
     cronUtilsVersion = '9.1.6'
     uuidCreatorVersion = '2.7.10'
 


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## ❓ Context <!-- why this change is made -->
Bump db-scheduler version to 11.0 to close vulnerability

## 🚀 Changes <!-- what this PR does -->


## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
