### PR TITLE
Bump idempotence4j version to 2.0.0 - add missing release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<a href="https://img.shields.io/badge/release-1.7.3-orange">
-        <img src="https://img.shields.io/badge/release-1.7.3-orange"
+<a href="https://img.shields.io/badge/release-2.0.0-orange">
+        <img src="https://img.shields.io/badge/release-2.0.0-orange"
             alt="Release version"/></a>
 
 # idempotence4j


### PR DESCRIPTION
## Context
The 2.0.0 release was missing the corresponding git tag, which caused the release job to fail. This PR updates the README release badge to reflect version 2.0.0 and adds the missing release tag.

## Changes
- Add missing release tag
- Update README.md release badge to display version 2.0.0
